### PR TITLE
fix: recover pending permissions, questions, and session status on reconnect

### DIFF
--- a/frontend/src/api-client.ts
+++ b/frontend/src/api-client.ts
@@ -10,6 +10,7 @@ import type {
   QuestionAnswer,
   QuestionRequest,
   Session,
+  SessionStatus,
 } from "@opencode-ai/sdk/v2/client";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
@@ -94,4 +95,22 @@ export async function rejectQuestion(requestID: string): Promise<void> {
 export async function fetchSessionDiff(sessionID: string): Promise<FileDiff[]> {
   const result = await client.session.diff({ sessionID });
   return (result.data ?? []) as FileDiff[];
+}
+
+export async function fetchPendingPermissions(): Promise<PermissionRequest[]> {
+  const result = await client.permission.list();
+  return (result.data ?? []) as PermissionRequest[];
+}
+
+export async function fetchPendingQuestions(): Promise<QuestionRequest[]> {
+  const result = await client.question.list();
+  return (result.data ?? []) as QuestionRequest[];
+}
+
+export async function fetchSessionStatus(
+  sessionID: string,
+): Promise<SessionStatus | undefined> {
+  const result = await client.session.status();
+  const statuses = result.data as Record<string, SessionStatus> | undefined;
+  return statuses?.[sessionID];
 }

--- a/frontend/src/streaming.ts
+++ b/frontend/src/streaming.ts
@@ -7,6 +7,9 @@
 
 import {
   fetchMessages,
+  fetchPendingPermissions,
+  fetchPendingQuestions,
+  fetchSessionStatus,
   fetchSessions,
   respondToPermission,
   sendPromptAsync,
@@ -209,16 +212,52 @@ export function openStream(sessionId: string): void {
   setIsStreaming(false);
   setErrorMessage(null);
   setPendingPermission(null);
+  setPendingQuestion(null);
   pendingText = "";
 
   // Load existing messages
   void fetchMessages(sessionId).then(setMessages);
 
-  // Subscribe to global events
+  // Subscribe to global events (do this before polling so we don't miss events)
   void subscribeToEvents(handleEvent).catch((err: unknown) => {
     if (err instanceof Error && err.name === "AbortError") return;
     const msg = err instanceof Error ? err.message : "Event stream error";
     setErrorMessage(msg);
+  });
+
+  // Poll for pending state that may have been missed (permissions, questions, session status)
+  void Promise.all([
+    fetchPendingPermissions().catch((err: unknown) => {
+      console.warn("Failed to fetch pending permissions:", err);
+      return [] as Awaited<ReturnType<typeof fetchPendingPermissions>>;
+    }),
+    fetchPendingQuestions().catch((err: unknown) => {
+      console.warn("Failed to fetch pending questions:", err);
+      return [] as Awaited<ReturnType<typeof fetchPendingQuestions>>;
+    }),
+    fetchSessionStatus(sessionId).catch((err: unknown) => {
+      console.warn("Failed to fetch session status:", err);
+      return undefined;
+    }),
+  ]).then(([permissions, questions, status]) => {
+    // Only apply if we're still on the same session
+    if (currentSessionId !== sessionId) return;
+
+    const sessionPermission = permissions.find(
+      (p) => p.sessionID === sessionId,
+    );
+    if (sessionPermission) {
+      setPendingPermission(sessionPermission);
+    }
+
+    const sessionQuestion = questions.find((q) => q.sessionID === sessionId);
+    if (sessionQuestion) {
+      setPendingQuestion(sessionQuestion);
+    }
+
+    if (status?.type === "busy") {
+      setIsStreaming(true);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- Polls `permission.list()`, `question.list()`, and `session.status()` SDK endpoints when opening a session stream, so pending UI state is restored after page refresh or session switch
- Fixes a bug where refreshing the page while a permission prompt or question dialog was showing would leave the agent stuck waiting for a reply that never comes
- Also fixes a missing `setPendingQuestion(null)` reset in `openStream()`

## Details

Previously, `pendingPermission`, `pendingQuestion`, and `isStreaming` were only populated from live SSE events. The SSE stream is live-only (no replay on reconnect), so any pending state was silently lost on page refresh or session switch.

The fix adds a `Promise.all` polling block in `openStream()` that runs in parallel after SSE subscription (so no events are missed during the poll window). Each poll has independent error handling so one failure doesn't block the others, and results are guarded against stale session switches.

## Changes

- **`frontend/src/api-client.ts`**: Added `fetchPendingPermissions()`, `fetchPendingQuestions()`, and `fetchSessionStatus()` wrappers
- **`frontend/src/streaming.ts`**: Added pending state polling in `openStream()`, fixed missing `setPendingQuestion(null)` reset