### PR TITLE
feat: make chat input multiline with auto-resize

### DIFF
--- a/frontend/src/components/ChatMain.tsx
+++ b/frontend/src/components/ChatMain.tsx
@@ -31,7 +31,7 @@ import { ToolConfirmBlock } from "./ToolConfirmBlock";
 export function ChatMain() {
   let messagesRef: HTMLDivElement | undefined;
   let scrollSentinel: HTMLDivElement | undefined;
-  let inputRef: HTMLInputElement | undefined;
+  let inputRef: HTMLTextAreaElement | undefined;
 
   const [animateSnap, setAnimateSnap] = createSignal(false);
   let pendingNav: (() => void) | null = null;
@@ -109,8 +109,25 @@ export function ChatMain() {
     if (!value || isStreaming()) return;
     if (inputRef) {
       inputRef.value = "";
+      inputRef.style.height = "auto";
     }
     void sendUserMessage(value);
+  }
+
+  function handleKeyDown(e: KeyboardEvent): void {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      const form = inputRef?.closest("form");
+      if (form) {
+        form.requestSubmit();
+      }
+    }
+  }
+
+  function handleAutoResize(): void {
+    if (!inputRef) return;
+    inputRef.style.height = "auto";
+    inputRef.style.height = `${inputRef.scrollHeight}px`;
   }
 
   const showLeftArrow = () => {
@@ -173,13 +190,15 @@ export function ChatMain() {
       </div>
 
       <form id="chat-form" onSubmit={handleSubmit}>
-        <input
+        <textarea
           ref={inputRef}
           id="chat-input"
-          type="text"
           placeholder="Send a message…"
           autocomplete="off"
           disabled={isStreaming()}
+          rows={1}
+          onKeyDown={handleKeyDown}
+          onInput={handleAutoResize}
         />
         <button type="submit" class="btn" disabled={isStreaming()}>
           Send

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -383,6 +383,7 @@ h1 {
 
 #chat-form {
   display: flex;
+  align-items: flex-end;
   gap: 0.5rem;
 }
 
@@ -396,6 +397,10 @@ h1 {
   font-family: var(--font-sans);
   font-size: 0.9rem;
   outline: none;
+  resize: none;
+  overflow-y: auto;
+  max-height: 10rem;
+  line-height: 1.4;
 }
 
 #chat-input:focus {


### PR DESCRIPTION
## Summary
- Replace the single-line `<input>` with a `<textarea>` that starts at one row and auto-grows as the user types, capping at ~10rem with scroll overflow.
- Enter submits the message; Shift+Enter inserts a newline.
- Send button stays anchored to the bottom of the form as the textarea expands.