### PR TITLE
fix: load messages on first page load when URL hash already set

### DIFF
--- a/frontend/src/sessions.ts
+++ b/frontend/src/sessions.ts
@@ -142,5 +142,12 @@ export async function initSessions(): Promise<void> {
   const hashId = sessionIdFromHash();
   const target =
     hashId && list.some((s) => s.id === hashId) ? hashId : list[0]!.id;
-  switchToSession(target);
+
+  // Always open the stream on init — bypass switchToSession's same-ID guard,
+  // which would skip openStream when the URL hash already matches (e.g. page reload).
+  setSessionHash(target);
+  setIsStreaming(false);
+  setErrorMessage(null);
+  setPendingPermission(null);
+  openStream(target);
 }


### PR DESCRIPTION
## Summary

- Fix a bug where messages don't render on first page load when the URL hash already contains a session ID (e.g. page reload)

## Root Cause

`initSessions()` calls `switchToSession(target)`, which has a same-ID guard: `if (activeSessionId() === sessionId) return;`. On page reload, the URL hash is already set from the previous visit, so `activeSessionId()` matches `target` and `openStream()` is never called. Messages are never fetched.

Switching to another session and back works because the IDs differ, so the guard passes.

## Fix

Inline the setup steps (`setSessionHash`, reset state, `openStream`) directly in `initSessions()`, bypassing the guard. The guard is correct for user-initiated session switches (preventing redundant work) but wrong for initial bootstrap.