### PR TITLE
PR 1/4: Gateway scaffold + tunnel client (headless backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ Thumbs.db
 
 # Go / tsnet-proxy
 tsnet-proxy/tsnet-proxy
+gateway/gateway
+gateway/voxpilot-gateway
+tunnel-client/tunnel-client
+tunnel-client/voxpilot-tunnel

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,7 @@
-import { existsSync, statSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
 import { createOpencode } from "@opencode-ai/sdk/v2";
 import { Hono } from "hono";
-import { serveStatic } from "hono/bun";
 import { cors } from "hono/cors";
 import { closeDb, getDb } from "./db";
 import { createMcpRouter } from "./mcp";
@@ -34,7 +33,10 @@ Environment:
   VOXPILOT_PORT             HTTP port (default 8000)
   VOXPILOT_OC_PORT          Embedded OpenCode server port (default: auto-pick)
   VOXPILOT_DB_PATH          SQLite database path (default voxpilot.db)
-  VOXPILOT_WAKE_URL         Optional Home Assistant webhook for Wake-on-LAN
+
+VoxPilot is a headless API server. The frontend is served by the gateway
+(see gateway/ in the source tree, deployed as a Docker container).
+Use voxpilot-tunnel to expose this backend through a remote gateway.
 
 Requires the 'opencode' binary on PATH (https://opencode.ai/docs).`);
   process.exit(0);
@@ -75,14 +77,10 @@ const APP_PORT = Number(process.env.VOXPILOT_PORT ?? 8000);
 // The actual port is reported by the SDK via `server.url`.
 const OC_PORT = Number(process.env.VOXPILOT_OC_PORT ?? 0);
 
-// Resolve the static assets directory. In production (compiled binary),
-// the `static/` folder sits next to the binary. In development (running from
-// source), it lives at backend/static (i.e. ../static relative to src/).
-const staticRoot = (() => {
-  const beside = resolve(dirname(process.execPath), "static");
-  if (existsSync(beside)) return beside;
-  return resolve(import.meta.dir, "../static");
-})();
+// VoxPilot is a headless API server. The frontend is served by the gateway
+// (gateway/ in the source tree, deployed as a Docker container in front of
+// the fleet of backends). In dev, Vite serves the frontend on :3000 and
+// proxies /api and /oc here. There is no in-binary static-file serving.
 
 // Cache OpenCode server across hot reloads (globalThis survives Bun reloads)
 const _global = globalThis as typeof globalThis & {
@@ -129,11 +127,9 @@ export const app = appBase
   .route("/api/review", createReviewRouter(workDir))
   .route("/api/config", createConfigRouter());
 
-// Proxy and static don't need RPC types — keep imperative
+// Proxy doesn't need RPC types -- keep imperative
 const OC_PREFIX = "/oc";
 app.all(`${OC_PREFIX}/*`, proxy(ocServer.url, OC_PREFIX));
-app.use("/*", serveStatic({ root: staticRoot }));
-app.use("/*", serveStatic({ root: staticRoot, path: "index.html" }));
 
 export type AppType = typeof app;
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,84 @@
+# voxpilot-gateway
+
+The gateway is the single internet-facing component of a multi-host VoxPilot
+deployment. Browsers reach it over HTTPS (terminated by Caddy upstream),
+backend hosts reach it via outbound WebSocket tunnels, and the gateway
+brokers HTTP requests between the two.
+
+In Phase 1 (this PR), the gateway is a thin proxy + tunnel server. The
+frontend is not yet embedded; the picker UI and WoL endpoints land in
+later phases.
+
+## Routing
+
+| Path                              | Handled by                         |
+| --------------------------------- | ---------------------------------- |
+| `GET  /api/gateway/tunnel`        | WebSocket; tunnel clients connect  |
+| `GET  /api/gateway/instances`     | JSON list of registered backends   |
+| `*    /backends/{name}/...`       | Proxied to that backend's tunnel   |
+| `*    /...`                       | 404 (Phase 2: frontend assets)     |
+
+Path stripping: a request for `/backends/devbox/api/health` arrives at the
+backend as `/api/health`. The original `Host` header is preserved.
+
+## Configuration
+
+| Env var                     | Default | Notes                                      |
+| --------------------------- | ------- | ------------------------------------------ |
+| `VPGW_BIND`                 | `:8080` | HTTP listen address                        |
+| `VPGW_TUNNEL_TOKEN`         | _none_  | **Required.** Shared secret for tunnels.   |
+| `VPGW_HEARTBEAT_TIMEOUT`    | `60s`   | Mark instance offline after this gap       |
+
+## Tunnel protocol
+
+Tunnel clients connect with `Authorization: Bearer <token>` to upgrade the
+WebSocket. The connection is wrapped as a `yamux` session; the client opens
+a control stream and sends a JSON-line `helloMsg`:
+
+```json
+{"proto": 1, "name": "devbox", "version": "0.1.42+abc1234", "wake_url": "..."}
+```
+
+Heartbeats (`{"type": "heartbeat"}`) flow on the same control stream every
+~30s. The gateway opens a fresh yamux stream for every inbound HTTP request
+and uses `httputil.ReverseProxy` over it, with `FlushInterval: -1` to keep
+SSE responses unbuffered.
+
+## Build
+
+```sh
+go build -o voxpilot-gateway ./...
+```
+
+A Dockerfile lives alongside this README (Phase 4 will wire it into the
+release pipeline).
+
+## Local smoke test
+
+```sh
+# Terminal 1: gateway
+VPGW_BIND=:18080 VPGW_TUNNEL_TOKEN=dev ./voxpilot-gateway
+
+# Terminal 2: a fake local backend
+python3 -m http.server 18000
+
+# Terminal 3: tunnel client (from ../tunnel-client)
+VOXPILOT_GATEWAY_URL=ws://127.0.0.1:18080/api/gateway/tunnel \
+  VOXPILOT_GATEWAY_TOKEN=dev \
+  VOXPILOT_INSTANCE_NAME=smoke \
+  VOXPILOT_LOCAL_URL=http://127.0.0.1:18000 \
+  ./voxpilot-tunnel
+
+# Terminal 4: hit the gateway
+curl http://127.0.0.1:18080/api/gateway/instances
+curl http://127.0.0.1:18080/backends/smoke/
+```
+
+## Known limitations (Phase 1)
+
+- No persistent state. Gateway restart loses all registrations until clients
+  reconnect (a few seconds with default backoff).
+- No WebSocket proxying through the tunnel. SSE works; raw WS upgrades do
+  not. VoxPilot does not currently use WS upstream of the tunnel.
+- No frontend serving. Picker UI lands in Phase 2.
+- No WoL endpoint. Lands in Phase 3.

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,0 +1,8 @@
+module github.com/voxpilot/gateway
+
+go 1.24
+
+require (
+	github.com/coder/websocket v1.8.13
+	github.com/hashicorp/yamux v0.1.2
+)

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,0 +1,4 @@
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -1,0 +1,99 @@
+// Package main implements the VoxPilot gateway.
+//
+// The gateway is the single internet-facing component of a multi-host
+// VoxPilot deployment. Browsers reach it over HTTPS (terminated by Caddy
+// upstream), backend hosts reach it via outbound WebSocket tunnels, and
+// the gateway brokers HTTP requests between the two.
+//
+// Routing surface:
+//
+//	GET  /api/gateway/tunnel              -- WebSocket; tunnel clients connect here
+//	GET  /api/gateway/instances           -- JSON list of registered backends
+//	POST /api/gateway/wake/{name}         -- (Phase 3) WoL passthrough to per-host webhook
+//	*    /backends/{name}/...             -- proxied to that backend over its tunnel
+//	*    /...                             -- (Phase 2) frontend static assets
+//
+// In Phase 1 the static frontend is not yet embedded; unknown paths return 404.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	bind := envOr("VPGW_BIND", ":8080")
+	tunnelToken := os.Getenv("VPGW_TUNNEL_TOKEN")
+	if tunnelToken == "" {
+		log.Fatal("VPGW_TUNNEL_TOKEN must be set (shared secret presented by tunnel clients)")
+	}
+
+	heartbeatTimeout := 60 * time.Second
+	if v := os.Getenv("VPGW_HEARTBEAT_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			log.Fatalf("invalid VPGW_HEARTBEAT_TIMEOUT %q: %v", v, err)
+		}
+		heartbeatTimeout = d
+	}
+
+	registry := newRegistry(heartbeatTimeout)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/gateway/tunnel", &tunnelHandler{
+		registry: registry,
+		token:    tunnelToken,
+	})
+	mux.HandleFunc("GET /api/gateway/instances", func(w http.ResponseWriter, r *http.Request) {
+		writeInstances(w, registry)
+	})
+	mux.Handle("/backends/", &proxyHandler{registry: registry})
+
+	// Phase 1 fallback: anything else is a 404. Phase 2 will replace this
+	// with embedded frontend assets + SPA fallback.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	srv := &http.Server{
+		Addr:    bind,
+		Handler: mux,
+		// SSE and tunneled requests are long-lived; don't impose write
+		// deadlines that would chop them off. Read header timeout protects
+		// against slowloris on initial request lines.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		log.Printf("shutting down...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("server shutdown: %v", err)
+		}
+		registry.closeAll()
+	}()
+
+	log.Printf("voxpilot-gateway listening on %s", bind)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("listen: %v", err)
+	}
+	log.Printf("stopped.")
+}

--- a/gateway/proxy.go
+++ b/gateway/proxy.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/yamux"
+)
+
+// proxyHandler routes /backends/{name}/... to the named instance's tunnel.
+// Path-prefix stripping: the backend sees the request at the same path it
+// would if it were called directly (e.g. /backends/devbox/api/health
+// becomes /api/health).
+type proxyHandler struct {
+	registry *registry
+}
+
+func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// /backends/{name}/...  -> name = first segment after the prefix
+	rest := strings.TrimPrefix(r.URL.Path, "/backends/")
+	if rest == r.URL.Path {
+		http.NotFound(w, r)
+		return
+	}
+	slash := strings.IndexByte(rest, '/')
+	var name, tail string
+	if slash < 0 {
+		name = rest
+		tail = "/"
+	} else {
+		name = rest[:slash]
+		tail = rest[slash:]
+	}
+	if name == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	inst := h.registry.get(name)
+	if inst == nil || inst.session == nil || inst.session.IsClosed() {
+		http.Error(w, fmt.Sprintf("backend %q not connected", name), http.StatusBadGateway)
+		return
+	}
+
+	// httputil.ReverseProxy with a Transport that dials over yamux.
+	// FlushInterval: -1 ensures SSE chunks are written to the client
+	// immediately rather than buffered.
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			// Don't use SetURL: it joins paths, but we want a full
+			// override (the prefix /backends/<name> has been stripped).
+			// Scheme/host are placeholders -- the transport dials directly
+			// through the tunnel and ignores them.
+			pr.Out.URL = &url.URL{
+				Scheme:   "http",
+				Host:     "tunnel",
+				Path:     tail,
+				RawQuery: r.URL.RawQuery,
+			}
+			// Preserve original Host so the backend sees what the browser
+			// sent (some Hono routes care).
+			pr.Out.Host = r.Host
+		},
+		Transport:     inst.transport,
+		FlushInterval: -1,
+		ErrorLog:      log.New(log.Writer(), "proxy: ", log.LstdFlags),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			// Tunnel-level errors (session closed mid-flight, stream
+			// reset) are common during reconnects; report as 502.
+			log.Printf("proxy: %s %s: %v", r.Method, r.URL.Path, err)
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		},
+	}
+
+	proxy.ServeHTTP(w, r)
+}
+
+// yamuxTransport is an http.RoundTripper that dials each request as a new
+// stream on a shared yamux session. We keep a single http.Transport instance
+// configured with DisableKeepAlives=true so each request gets a fresh stream
+// (yamux streams are cheap; pooling them under HTTP keep-alive interacts
+// badly with mid-stream session resets).
+type yamuxTransport struct {
+	session *yamux.Session
+	inner   *http.Transport
+}
+
+func newYamuxTransport(sess *yamux.Session) *yamuxTransport {
+	t := &yamuxTransport{session: sess}
+	t.inner = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return sess.Open()
+		},
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: 0, // SSE: unbounded time-to-first-byte
+		ExpectContinueTimeout: 1 * 1_000_000_000,
+	}
+	return t
+}
+
+func (t *yamuxTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.session == nil || t.session.IsClosed() {
+		return nil, errors.New("yamux session closed")
+	}
+	return t.inner.RoundTrip(req)
+}

--- a/gateway/registry.go
+++ b/gateway/registry.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/yamux"
+)
+
+// instance is a single registered backend, with its yamux session if connected.
+//
+// Lifecycle: created on tunnel connect (registerControl), updated by heartbeats,
+// removed on tunnel disconnect. Phase 1 keeps no on-disk state; if the gateway
+// restarts, registrations are lost (clients reconnect within seconds).
+type instance struct {
+	name        string
+	wakeURL     string // optional HA webhook; nil for now in phase 1
+	version     string
+	session     *yamux.Session
+	transport   *yamuxTransport // built once per session
+	connectedAt time.Time
+	lastSeen    time.Time
+}
+
+type registry struct {
+	mu               sync.RWMutex
+	instances        map[string]*instance
+	heartbeatTimeout time.Duration
+}
+
+func newRegistry(heartbeatTimeout time.Duration) *registry {
+	return &registry{
+		instances:        map[string]*instance{},
+		heartbeatTimeout: heartbeatTimeout,
+	}
+}
+
+// register installs (or replaces) an instance. If a previous session exists
+// for the same name, it is closed -- last-write-wins, with a warning logged
+// by the caller.
+func (r *registry) register(inst *instance) (replaced bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	old, existed := r.instances[inst.name]
+	if existed && old.session != nil {
+		_ = old.session.Close()
+		replaced = true
+	}
+	r.instances[inst.name] = inst
+	return
+}
+
+// remove drops an instance, but only if the recorded session matches the one
+// passed in. This avoids races where a reconnect installs a new session
+// between the time the old session's read loop exits and we get here.
+func (r *registry) remove(name string, sess *yamux.Session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst, ok := r.instances[name]
+	if !ok || inst.session != sess {
+		return
+	}
+	delete(r.instances, name)
+}
+
+func (r *registry) get(name string) *instance {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.instances[name]
+}
+
+func (r *registry) heartbeat(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst, ok := r.instances[name]
+	if !ok {
+		return false
+	}
+	inst.lastSeen = time.Now()
+	return true
+}
+
+func (r *registry) closeAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, inst := range r.instances {
+		if inst.session != nil {
+			_ = inst.session.Close()
+		}
+	}
+}
+
+// instanceView is the JSON shape returned by /api/gateway/instances.
+// Stable wire format -- the frontend depends on these field names.
+type instanceView struct {
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Online      bool      `json:"online"`
+	HasWake     bool      `json:"has_wake"`
+	ConnectedAt time.Time `json:"connected_at"`
+	LastSeen    time.Time `json:"last_seen"`
+}
+
+func (r *registry) snapshot() []instanceView {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := time.Now()
+	out := make([]instanceView, 0, len(r.instances))
+	for _, inst := range r.instances {
+		online := inst.session != nil &&
+			!inst.session.IsClosed() &&
+			now.Sub(inst.lastSeen) <= r.heartbeatTimeout
+		out = append(out, instanceView{
+			Name:        inst.name,
+			Version:     inst.version,
+			Online:      online,
+			HasWake:     inst.wakeURL != "",
+			ConnectedAt: inst.connectedAt,
+			LastSeen:    inst.lastSeen,
+		})
+	}
+	return out
+}
+
+func writeInstances(w http.ResponseWriter, r *registry) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(r.snapshot())
+}

--- a/gateway/tunnel.go
+++ b/gateway/tunnel.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/hashicorp/yamux"
+)
+
+// Wire format on the control stream. JSON-line framed: each message is a
+// single JSON object terminated by '\n'. Backwards-incompatible changes
+// must bump the protocol version (see helloMsg.Proto).
+
+type helloMsg struct {
+	Proto   int    `json:"proto"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	WakeURL string `json:"wake_url,omitempty"`
+}
+
+type heartbeatMsg struct {
+	Type string `json:"type"` // "heartbeat"
+}
+
+const protocolVersion = 1
+
+type tunnelHandler struct {
+	registry *registry
+	token    string
+}
+
+func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Bearer-token auth on the WS upgrade. We use a simple shared secret;
+	// when the gateway is exposed publicly this is all that prevents
+	// arbitrary clients from registering as a backend.
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) <= len(prefix) || auth[:len(prefix)] != prefix || auth[len(prefix):] != h.token {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// Tunnel clients connect from arbitrary origins (any backend host
+		// running tunnel-client). The token is the security boundary, not
+		// the Origin header.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		log.Printf("tunnel: ws accept failed: %v", err)
+		return
+	}
+
+	// Tunnels stay open indefinitely; let the underlying request context
+	// die only when the connection closes. websocket.NetConn handles
+	// CloseRead -- needed so reads in the yamux session can detect
+	// client-side closes promptly.
+	ctx := r.Context()
+	wsConn := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+
+	// Gateway is the yamux server: clients (tunnel-clients) initiate
+	// streams for control, and the gateway initiates streams when
+	// proxying HTTP requests inbound.
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = io.Discard // yamux is chatty; route logs through our own logger
+	sess, err := yamux.Server(wsConn, cfg)
+	if err != nil {
+		log.Printf("tunnel: yamux server: %v", err)
+		_ = ws.Close(websocket.StatusInternalError, "yamux init failed")
+		return
+	}
+	defer sess.Close()
+
+	// Wait for the client's control stream and hello message.
+	// Anything that takes more than 10s is suspicious; reject it.
+	acceptCtx, cancel := contextWithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	control, err := sess.AcceptStreamWithContext(acceptCtx)
+	if err != nil {
+		log.Printf("tunnel: accept control stream: %v", err)
+		return
+	}
+
+	dec := json.NewDecoder(control)
+	var hello helloMsg
+	if err := dec.Decode(&hello); err != nil {
+		log.Printf("tunnel: read hello: %v", err)
+		return
+	}
+	if hello.Proto != protocolVersion {
+		log.Printf("tunnel: protocol version mismatch: client=%d server=%d", hello.Proto, protocolVersion)
+		return
+	}
+	if hello.Name == "" {
+		log.Printf("tunnel: hello missing name")
+		return
+	}
+
+	inst := &instance{
+		name:        hello.Name,
+		version:     hello.Version,
+		wakeURL:     hello.WakeURL,
+		session:     sess,
+		transport:   newYamuxTransport(sess),
+		connectedAt: time.Now(),
+		lastSeen:    time.Now(),
+	}
+	if replaced := h.registry.register(inst); replaced {
+		log.Printf("tunnel: %s reconnected (previous session replaced)", inst.name)
+	} else {
+		log.Printf("tunnel: %s connected (version=%s)", inst.name, inst.version)
+	}
+	defer func() {
+		h.registry.remove(inst.name, sess)
+		log.Printf("tunnel: %s disconnected", inst.name)
+	}()
+
+	// Read heartbeats from the control stream until the client goes away.
+	// yamux's own keepalive (default: 30s ping) handles transport-level
+	// liveness; the heartbeat message updates the per-instance lastSeen
+	// timestamp shown in the picker UI.
+	for {
+		var msg heartbeatMsg
+		if err := dec.Decode(&msg); err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.Printf("tunnel: %s control read: %v", inst.name, err)
+			}
+			return
+		}
+		if msg.Type == "heartbeat" {
+			h.registry.heartbeat(inst.name)
+		}
+	}
+}

--- a/gateway/util.go
+++ b/gateway/util.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// contextWithTimeout returns a child of parent with the given timeout.
+// Wraps context.WithTimeout for tests/mocks; kept trivial.
+func contextWithTimeout(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, d)
+}

--- a/tunnel-client/README.md
+++ b/tunnel-client/README.md
@@ -1,0 +1,45 @@
+# voxpilot-tunnel
+
+The host-side sidecar that joins a backend to a remote VoxPilot gateway.
+
+Each VoxPilot host runs three things:
+
+1. `voxpilot` -- the Bun backend, listening on `127.0.0.1:8000` (loopback
+   only, completely unaware of the gateway)
+2. `voxpilot-tunnel` -- this binary, which dials the gateway and forwards
+   inbound requests to the backend
+3. `opencode` -- on `PATH`, spawned by the backend
+
+The sidecar opens a single outbound WebSocket to the gateway, wraps it as
+a `yamux` client session, and:
+
+- Sends a one-shot `hello` message identifying this host (name, version,
+  optional WoL webhook URL)
+- Sends periodic heartbeats so the gateway can show fresh "last seen"
+  times in its picker UI
+- Accepts incoming yamux streams from the gateway, treats each as a
+  single inbound HTTP request, forwards it to the local backend, and
+  streams the response back
+
+## Configuration
+
+| Env var                     | Default              | Notes                              |
+| --------------------------- | -------------------- | ---------------------------------- |
+| `VOXPILOT_GATEWAY_URL`      | _none_               | **Required.** `wss://...`          |
+| `VOXPILOT_GATEWAY_TOKEN`    | _none_               | **Required.** Shared with gateway. |
+| `VOXPILOT_LOCAL_URL`        | `http://127.0.0.1:8000` | Where the backend listens       |
+| `VOXPILOT_INSTANCE_NAME`    | `os.Hostname()`      | Becomes `/backends/<name>/...`     |
+| `VOXPILOT_WAKE_URL`         | _empty_              | Optional HA webhook (Phase 3)      |
+| `VOXPILOT_VERSION`          | `0.0.0-dev`          | Build-time injected normally       |
+
+## Reconnection
+
+On any disconnect, the client waits with exponential backoff (1s -> 30s,
+capped) and reconnects. Sessions that lasted >30s are treated as healthy
+and reset the backoff to 1s.
+
+## Build
+
+```sh
+go build -o voxpilot-tunnel ./...
+```

--- a/tunnel-client/client.go
+++ b/tunnel-client/client.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/hashicorp/yamux"
+)
+
+// Wire format on the control stream. Must match gateway/tunnel.go exactly.
+
+type helloMsg struct {
+	Proto   int    `json:"proto"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	WakeURL string `json:"wake_url,omitempty"`
+}
+
+type heartbeatMsg struct {
+	Type string `json:"type"`
+}
+
+const (
+	protocolVersion   = 1
+	heartbeatInterval = 30 * time.Second
+)
+
+type clientConfig struct {
+	gatewayURL string
+	token      string
+	localURL   string
+	wakeURL    string
+	name       string
+	version    string
+}
+
+// runOnce dials the gateway, registers, and serves until either the context
+// is cancelled or the session disconnects. Returns nil on clean shutdown,
+// otherwise the underlying error.
+func runOnce(ctx context.Context, cfg clientConfig) error {
+	// Validate the local URL early so the failure is obvious.
+	if _, err := url.Parse(cfg.localURL); err != nil {
+		return fmt.Errorf("invalid VOXPILOT_LOCAL_URL %q: %w", cfg.localURL, err)
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(dialCtx, cfg.gatewayURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + cfg.token}},
+	})
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	// Disable read limit -- HTTP request bodies through the tunnel can
+	// be arbitrarily large.
+	ws.SetReadLimit(-1)
+
+	wsConn := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+	defer wsConn.Close()
+
+	// Tunnel client is the yamux client side. It opens streams for control
+	// (and may open more in the future); the server (gateway) opens streams
+	// to forward inbound HTTP requests to us.
+	ycfg := yamux.DefaultConfig()
+	ycfg.LogOutput = io.Discard
+	sess, err := yamux.Client(wsConn, ycfg)
+	if err != nil {
+		return fmt.Errorf("yamux client: %w", err)
+	}
+	defer sess.Close()
+
+	// Open the control stream and send hello.
+	control, err := sess.Open()
+	if err != nil {
+		return fmt.Errorf("open control stream: %w", err)
+	}
+	defer control.Close()
+
+	enc := json.NewEncoder(control)
+	if err := enc.Encode(helloMsg{
+		Proto:   protocolVersion,
+		Name:    cfg.name,
+		Version: cfg.version,
+		WakeURL: cfg.wakeURL,
+	}); err != nil {
+		return fmt.Errorf("send hello: %w", err)
+	}
+	log.Printf("tunnel: connected, registered as %q", cfg.name)
+
+	forwarder := newForwarder(cfg.localURL)
+
+	// Three loops: heartbeats out, accept inbound streams (HTTP requests),
+	// and watch for context cancellation. Whichever exits first triggers
+	// the rest via the shared err channel.
+	errCh := make(chan error, 3)
+	var once sync.Once
+	finish := func(e error) { once.Do(func() { errCh <- e }) }
+
+	go func() {
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				finish(nil)
+				return
+			case <-sess.CloseChan():
+				finish(errors.New("session closed"))
+				return
+			case <-ticker.C:
+				if err := enc.Encode(heartbeatMsg{Type: "heartbeat"}); err != nil {
+					finish(fmt.Errorf("heartbeat: %w", err))
+					return
+				}
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			stream, err := sess.AcceptStream()
+			if err != nil {
+				finish(fmt.Errorf("accept stream: %w", err))
+				return
+			}
+			go forwarder.serve(stream)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		finish(nil)
+	}()
+
+	err = <-errCh
+	return err
+}

--- a/tunnel-client/forward.go
+++ b/tunnel-client/forward.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+)
+
+// forwarder turns inbound yamux streams into HTTP requests against the
+// local backend. Each stream carries a single HTTP/1.1 request/response.
+type forwarder struct {
+	target *url.URL
+	proxy  *httputil.ReverseProxy
+}
+
+func newForwarder(localURL string) *forwarder {
+	target, err := url.Parse(localURL)
+	if err != nil {
+		// Validated already in runOnce, but be defensive.
+		log.Fatalf("invalid local URL %q: %v", localURL, err)
+	}
+	f := &forwarder{target: target}
+	f.proxy = &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.Out.URL.Scheme = target.Scheme
+			pr.Out.URL.Host = target.Host
+			// Preserve path and query as the gateway sent them. The gateway
+			// has already stripped the /backends/<name> prefix.
+			pr.Out.Host = target.Host
+		},
+		FlushInterval: -1, // SSE: flush each chunk immediately
+		ErrorLog:      log.New(log.Writer(), "fwd: ", log.LstdFlags),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("fwd: %s %s: %v", r.Method, r.URL.Path, err)
+			http.Error(w, "local backend unreachable", http.StatusBadGateway)
+		},
+	}
+	return f
+}
+
+// serve handles one inbound stream as a single HTTP request.
+//
+// Implementation: wrap the stream as a one-shot net.Listener and run
+// http.Server.Serve on it. http.Server handles HTTP/1.1 framing, the
+// reverse proxy forwards to the local backend, the response is written
+// back through the same stream. After the request completes, http.Server
+// closes the connection (no keep-alive across yamux streams; the gateway
+// opens a new stream per request) and Serve returns ErrServerClosed
+// because the listener has already been drained.
+func (f *forwarder) serve(stream net.Conn) {
+	defer stream.Close()
+
+	ln := &oneShotListener{conn: stream}
+	srv := &http.Server{
+		Handler: f.proxy,
+		// Disable keep-alive: each stream serves exactly one request.
+		// (Even with this off http.Server doesn't proactively close after
+		// one request -- the listener returning EOF does.)
+		ErrorLog: log.New(log.Writer(), "stream-srv: ", log.LstdFlags),
+	}
+	srv.SetKeepAlivesEnabled(false)
+	if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, errListenerClosed) {
+		// Non-fatal; the gateway will treat as 502 on its side.
+		log.Printf("fwd: serve: %v", err)
+	}
+}
+
+// oneShotListener returns its single conn on the first Accept call,
+// then ErrListenerClosed forever after.
+type oneShotListener struct {
+	once   sync.Once
+	conn   net.Conn
+	closed chan struct{}
+	init   sync.Once
+}
+
+var errListenerClosed = errors.New("one-shot listener closed")
+
+func (l *oneShotListener) ensureInit() {
+	l.init.Do(func() { l.closed = make(chan struct{}) })
+}
+
+func (l *oneShotListener) Accept() (net.Conn, error) {
+	l.ensureInit()
+	var c net.Conn
+	l.once.Do(func() { c = l.conn })
+	if c != nil {
+		return c, nil
+	}
+	<-l.closed
+	return nil, errListenerClosed
+}
+
+func (l *oneShotListener) Close() error {
+	l.ensureInit()
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	return nil
+}
+
+func (l *oneShotListener) Addr() net.Addr {
+	if l.conn != nil {
+		return l.conn.LocalAddr()
+	}
+	return dummyAddr{}
+}
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "yamux" }
+func (dummyAddr) String() string  { return "yamux-stream" }

--- a/tunnel-client/go.mod
+++ b/tunnel-client/go.mod
@@ -1,0 +1,8 @@
+module github.com/voxpilot/tunnel-client
+
+go 1.24
+
+require (
+	github.com/coder/websocket v1.8.13
+	github.com/hashicorp/yamux v0.1.2
+)

--- a/tunnel-client/go.sum
+++ b/tunnel-client/go.sum
@@ -1,0 +1,4 @@
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=

--- a/tunnel-client/main.go
+++ b/tunnel-client/main.go
@@ -1,0 +1,120 @@
+// Package main implements voxpilot-tunnel, the host-side sidecar that
+// joins a backend to a remote VoxPilot gateway.
+//
+// The sidecar opens a single outbound WebSocket to the gateway, wraps it
+// as a yamux client session, and:
+//
+//   - Sends a one-shot "hello" message on a control stream, identifying
+//     this host (name, version, optional WoL webhook URL).
+//   - Sends periodic heartbeats on the same control stream so the gateway
+//     can show fresh "last seen" times in its picker.
+//   - Accepts incoming yamux streams from the gateway, treats each as a
+//     single inbound HTTP request, forwards it to the local VoxPilot
+//     backend on http://127.0.0.1:8000 (configurable), and streams the
+//     response back.
+//
+// The local backend is unaware of the gateway; from its perspective it
+// receives ordinary loopback HTTP requests.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// Build-time injected version. Reported to the gateway in the hello message
+// so the picker UI can warn about frontend/backend skew.
+var version = "0.0.0-dev"
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	gatewayURL := os.Getenv("VOXPILOT_GATEWAY_URL")
+	if gatewayURL == "" {
+		log.Fatal("VOXPILOT_GATEWAY_URL must be set (e.g. wss://voxpilot.example.com/api/gateway/tunnel)")
+	}
+	token := os.Getenv("VOXPILOT_GATEWAY_TOKEN")
+	if token == "" {
+		log.Fatal("VOXPILOT_GATEWAY_TOKEN must be set (shared secret with the gateway)")
+	}
+	localURL := envOr("VOXPILOT_LOCAL_URL", "http://127.0.0.1:8000")
+	wakeURL := os.Getenv("VOXPILOT_WAKE_URL")
+	name := envOr("VOXPILOT_INSTANCE_NAME", hostnameOr("voxpilot"))
+	if v := envOr("VOXPILOT_VERSION", ""); v != "" {
+		version = v
+	}
+
+	cfg := clientConfig{
+		gatewayURL: gatewayURL,
+		token:      token,
+		localURL:   localURL,
+		wakeURL:    wakeURL,
+		name:       name,
+		version:    version,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	log.Printf("voxpilot-tunnel %s: name=%s gateway=%s local=%s", version, name, gatewayURL, localURL)
+	runWithBackoff(ctx, cfg)
+	log.Printf("stopped.")
+}
+
+// runWithBackoff dials the gateway and runs one session at a time. On any
+// disconnect it waits with exponential backoff (capped) and reconnects,
+// until the context is cancelled.
+func runWithBackoff(ctx context.Context, cfg clientConfig) {
+	const (
+		minDelay = 1 * time.Second
+		maxDelay = 30 * time.Second
+	)
+	delay := minDelay
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		started := time.Now()
+		err := runOnce(ctx, cfg)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			log.Printf("tunnel: session ended: %v", err)
+		} else {
+			log.Printf("tunnel: session ended cleanly")
+		}
+		// If the session lasted long enough that the connection was
+		// healthy, reset backoff. Otherwise grow it.
+		if time.Since(started) > 30*time.Second {
+			delay = minDelay
+		} else {
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+		}
+		log.Printf("tunnel: reconnecting in %s", delay)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+func hostnameOr(fallback string) string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary

Phase 1 of the multi-host gateway architecture (planned in chat).

- **`gateway/`** — new Go binary; accepts WS tunnels from backends, proxies `/backends/<name>/...` traffic over yamux streams. Supports SSE / streaming responses (`FlushInterval: -1`).
- **`tunnel-client/`** — new Go sidecar; runs on each backend host, dials gateway, registers, accepts inbound HTTP requests, forwards to local `127.0.0.1:8000`. Reconnects with exponential backoff.
- **`backend/`** — drops in-binary static asset serving and SPA fallback. Now a pure API server. The frontend will move to the gateway in PR 2.

## What works

- `/api/gateway/instances` — JSON list of registered backends
- `/backends/<name>/...` — proxied to that backend with prefix stripped
- Bearer-token auth on tunnel connections
- Reconnect + heartbeats + clean shutdown
- SSE streaming verified end-to-end against real OpenCode `/oc/global/event`
- Real-backend smoke test: `/api/config`, `/oc/app`, and SSE all round-trip correctly

## Known limitations (intentional, addressed in later PRs)

- No frontend served by the gateway yet (PR 2)
- No picker UI (PR 2)
- No WoL endpoint (PR 3)
- No persistent registry — gateway restart loses registrations until clients reconnect (acceptable; reconnect within seconds)
- No WebSocket upgrade proxying — verified VoxPilot doesn't currently use WS on any proxied path
- Build script unchanged — release tarball still bundles a useless `static/` dir; PR 4 fixes

## Routing surface

| Path | Handler |
|---|---|
| `GET /api/gateway/tunnel` | WS upgrade for tunnel clients |
| `GET /api/gateway/instances` | JSON list |
| `* /backends/{name}/...` | Reverse-proxy over yamux |
| `* /...` | 404 (PR 2: frontend assets) |

## Tunnel protocol (v1)

Client opens WS with `Authorization: Bearer <token>` → wraps as yamux client → opens control stream → sends `{proto: 1, name, version, wake_url?}` → sends periodic `{type: "heartbeat"}`. Gateway opens new yamux streams to forward inbound HTTP requests.

## Smoke testing

See `gateway/README.md` for the local smoke-test recipe.

## Next

PR 2 (`gateway/02-frontend`) extracts the frontend into the gateway and adds the picker UI.