### PR TITLE
PR 2/4: Move frontend into gateway; add picker page

### DIFF
--- a/frontend/src/Picker.tsx
+++ b/frontend/src/Picker.tsx
@@ -1,0 +1,131 @@
+/**
+ * Picker page -- standalone entry point shown when the gateway serves
+ * the frontend at "/" (no backend selected). Lists registered backends
+ * and links to /backends/<name>/.
+ *
+ * This file is dynamically imported only in PICKER_MODE so it doesn't
+ * pull in api-client / store / etc.
+ */
+
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+
+type InstanceView = {
+  name: string;
+  version: string;
+  online: boolean;
+  has_wake: boolean;
+  connected_at: string;
+  last_seen: string;
+};
+
+type FetchState =
+  | { kind: "loading" }
+  | { kind: "ok"; instances: InstanceView[] }
+  | { kind: "error"; message: string };
+
+const REFRESH_INTERVAL = 5000;
+
+export function Picker() {
+  const [state, setState] = createSignal<FetchState>({ kind: "loading" });
+
+  async function refresh() {
+    try {
+      const resp = await fetch("/api/gateway/instances", {
+        cache: "no-store",
+      });
+      if (!resp.ok) {
+        setState({
+          kind: "error",
+          message: `gateway returned HTTP ${resp.status}`,
+        });
+        return;
+      }
+      const instances = (await resp.json()) as InstanceView[];
+      // Sort: online first, then alphabetical.
+      instances.sort((a, b) => {
+        if (a.online !== b.online) return a.online ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+      setState({ kind: "ok", instances });
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  onMount(() => {
+    void refresh();
+    const id = window.setInterval(() => void refresh(), REFRESH_INTERVAL);
+    onCleanup(() => window.clearInterval(id));
+  });
+
+  return (
+    <div class="picker-root">
+      <header class="picker-header">
+        <h1>VoxPilot</h1>
+        <p class="picker-subtitle">Choose a backend.</p>
+      </header>
+      <Show
+        when={state().kind === "ok"}
+        fallback={
+          <Show
+            when={state().kind === "error"}
+            fallback={<p class="picker-status">Loading...</p>}
+          >
+            <p class="picker-status picker-error">
+              Could not load backends: {(state() as { message: string }).message}
+            </p>
+          </Show>
+        }
+      >
+        <PickerList state={state} />
+      </Show>
+    </div>
+  );
+}
+
+function PickerList(props: { state: () => FetchState }) {
+  const instances = () => {
+    const s = props.state();
+    return s.kind === "ok" ? s.instances : [];
+  };
+  return (
+    <Show
+      when={instances().length > 0}
+      fallback={<p class="picker-status">No backends registered yet.</p>}
+    >
+      <ul class="picker-list">
+        <For each={instances()}>{(inst) => <PickerRow inst={inst} />}</For>
+      </ul>
+    </Show>
+  );
+}
+
+function PickerRow(props: { inst: InstanceView }) {
+  const href = () => `/backends/${encodeURIComponent(props.inst.name)}/`;
+  return (
+    <li
+      classList={{
+        "picker-row": true,
+        "picker-row-online": props.inst.online,
+        "picker-row-offline": !props.inst.online,
+      }}
+    >
+      <a class="picker-link" href={href()}>
+        <span class="picker-name">{props.inst.name}</span>
+        <span class="picker-meta">
+          <span
+            classList={{
+              "picker-status-dot": true,
+              online: props.inst.online,
+            }}
+            title={props.inst.online ? "online" : "offline"}
+          />
+          <span class="picker-version">{props.inst.version || "unknown"}</span>
+        </span>
+      </a>
+    </li>
+  );
+}

--- a/frontend/src/api-client.ts
+++ b/frontend/src/api-client.ts
@@ -24,6 +24,7 @@ import type {
   Worktree,
 } from "@opencode-ai/sdk/v2/client";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { BACKEND_PREFIX } from "./backend-base";
 
 export type {
   Agent,
@@ -45,7 +46,7 @@ export type MessageWithParts = {
 };
 
 export const client = createOpencodeClient({
-  baseUrl: `${window.location.origin}/oc`,
+  baseUrl: `${window.location.origin}${BACKEND_PREFIX}/oc`,
 });
 
 // ── Global SSE event stream ─────────────────────────────────────

--- a/frontend/src/backend-base.ts
+++ b/frontend/src/backend-base.ts
@@ -1,0 +1,82 @@
+/**
+ * Runtime base path and backend selection.
+ *
+ * The frontend bundle is served by the gateway at two URL shapes:
+ *   - `/`                       -> picker page (no backend selected)
+ *   - `/backends/<name>/...`    -> the app, scoped to backend <name>
+ *
+ * Detection happens once, at module load, from `window.location.pathname`.
+ * The chosen prefix is then used by `api-client.ts` and `rpc.ts` to build
+ * the URLs they hit:
+ *
+ *   - OpenCode SDK base: `<origin><BACKEND_PREFIX>/oc`
+ *   - Hono RPC base:     `<origin><BACKEND_PREFIX>/api`
+ *
+ * Switching backends is intentionally a full page navigation (`<a href>`,
+ * not router `<A>`): the app's module-level singletons (SSE pump, store
+ * init, navigation hash sync) are bound to one backend at boot. A page
+ * load is the cheapest way to bind them to a different one without
+ * threading a backend parameter through every call site.
+ *
+ * Standalone / dev mode: when neither `/` nor `/backends/...` matches
+ * (e.g. running Vite directly at `:3000`), we treat that as standalone
+ * mode -- BACKEND_PREFIX is empty, /api and /oc are reached at the root,
+ * and there is no picker route. This preserves the today-style dev loop.
+ */
+
+const BACKEND_ROUTE = /^\/backends\/([^/]+)(\/.*)?$/;
+
+function detect(): {
+  prefix: string;
+  name: string | null;
+  pickerMode: boolean;
+} {
+  const path = window.location.pathname;
+  const m = BACKEND_ROUTE.exec(path);
+  if (m) {
+    const name = m[1] ?? "";
+    return { prefix: `/backends/${name}`, name, pickerMode: false };
+  }
+  // Vite dev: serves the SPA at "/" with backend proxied at /api and /oc.
+  // The picker would just spin showing a 404 since there's no gateway. Stay
+  // in standalone mode so today's `just dev` workflow keeps working.
+  if (import.meta.env.DEV) {
+    return { prefix: "", name: null, pickerMode: false };
+  }
+  // Production at the gateway root: picker page.
+  if (path === "/" || path === "") {
+    return { prefix: "", name: null, pickerMode: true };
+  }
+  // Anything else is standalone mode -- a single-host deployment with no
+  // gateway. Use root paths and hide the picker. (Today this branch is
+  // unreachable in prod since the gateway only serves /, /backends/, and
+  // /assets/; included for forward compatibility with embedded deployments.)
+  return { prefix: "", name: null, pickerMode: false };
+}
+
+const { prefix, name, pickerMode } = detect();
+
+/** Path prefix to prepend to /api and /oc URLs. Empty in standalone mode. */
+export const BACKEND_PREFIX = prefix;
+
+/** Selected backend name (null when in picker or standalone mode). */
+export const BACKEND_NAME = name;
+
+/**
+ * True when the URL is exactly "/" and the gateway is expected -- the app
+ * should render the picker UI instead of booting the chat app.
+ */
+export const PICKER_MODE = pickerMode;
+
+/**
+ * Build a localStorage key that's automatically scoped to the current
+ * backend, so the same browser can hold separate state per backend
+ * without collisions. In standalone mode (no backend name) the key is
+ * unscoped, preserving today's behavior.
+ *
+ * Example: `backendStorageKey("wakeUrl")` => `"voxpilot:devbox:wakeUrl"`
+ * (or just `"voxpilot:wakeUrl"` in standalone mode).
+ */
+export function backendStorageKey(suffix: string): string {
+  return name ? `voxpilot:${name}:${suffix}` : `voxpilot:${suffix}`;
+}

--- a/frontend/src/components/OfflineOverlay.tsx
+++ b/frontend/src/components/OfflineOverlay.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "solid-js";
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import WifiOff from "lucide-solid/icons/wifi-off";
+import { backendStorageKey } from "../backend-base";
 import { rpc } from "../rpc";
 
 const PROBE_INTERVAL = 5_000;
@@ -130,10 +131,10 @@ export function OfflineOverlay(props: { children: JSX.Element }) {
       const data = await r.json();
       if (data.wakeUrl) {
         setWakeUrl(data.wakeUrl);
-        localStorage.setItem("voxpilot:wakeUrl", data.wakeUrl);
+        localStorage.setItem(backendStorageKey("wakeUrl"), data.wakeUrl);
       }
     } catch {
-      const stored = localStorage.getItem("voxpilot:wakeUrl");
+      const stored = localStorage.getItem(backendStorageKey("wakeUrl"));
       if (stored) setWakeUrl(stored);
     }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,8 +1,9 @@
 import type { Component } from "solid-js";
 import { createSignal, Show } from "solid-js";
 import { Dynamic, render } from "solid-js/web";
-import { Spinner } from "./components/Spinner";
+import { backendStorageKey, PICKER_MODE } from "./backend-base";
 import { OfflineOverlay } from "./components/OfflineOverlay";
+import { Spinner } from "./components/Spinner";
 import { rpc } from "./rpc";
 import { extractErrorMessage, showToast } from "./toast";
 import "./style.css";
@@ -19,40 +20,57 @@ window.addEventListener(
   },
 );
 
-// ── Dynamic app import ──────────────────────────────────────────────────────
-// Triggers store.ts's top-level await (init), streaming setup, and the
-// entire component tree. A signal + <Show> replaces lazy() + <Suspense>
-// so that no app-level Suspense boundary exists — stray createResource
-// calls in child components can never tear down the component tree.
-const [AppComponent, setAppComponent] = createSignal<Component>();
-
-import("./App").then(
-  (m) => {
-    setAppComponent(() => m.default);
-    // Persist wake URL for offline fallback
-    rpc.api.config
-      .$get()
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.wakeUrl) {
-          localStorage.setItem("voxpilot:wakeUrl", data.wakeUrl);
-        }
-      })
-      .catch(() => {});
-  },
-  (err) => showToast(extractErrorMessage(err)),
-);
-
 const root = document.getElementById("root");
-if (root) {
-  render(
-    () => (
-      <OfflineOverlay>
-        <Show when={AppComponent()} fallback={<Spinner fullscreen />}>
-          {(App) => <Dynamic component={App()} />}
-        </Show>
-      </OfflineOverlay>
-    ),
-    root,
+
+// ── Picker mode (no backend selected) ────────────────────────────────────────
+// When served at the root by the gateway with no /backends/<name>/ prefix,
+// render the picker page instead of booting the chat app. This avoids
+// triggering store.ts's top-level await(init()), which would attempt to call
+// the OpenCode SDK against a nonexistent backend.
+if (PICKER_MODE) {
+  if (root) {
+    import("./Picker").then(
+      (m) => {
+        render(() => <m.Picker />, root);
+      },
+      (err) => showToast(extractErrorMessage(err)),
+    );
+  }
+} else {
+  // ── Backend-bound app (or standalone dev) ──────────────────────────────────
+  // Triggers store.ts's top-level await (init), streaming setup, and the
+  // entire component tree. A signal + <Show> replaces lazy() + <Suspense>
+  // so that no app-level Suspense boundary exists -- stray createResource
+  // calls in child components can never tear down the component tree.
+  const [AppComponent, setAppComponent] = createSignal<Component>();
+
+  import("./App").then(
+    (m) => {
+      setAppComponent(() => m.default);
+      // Persist wake URL for offline fallback
+      rpc.api.config
+        .$get()
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.wakeUrl) {
+            localStorage.setItem(backendStorageKey("wakeUrl"), data.wakeUrl);
+          }
+        })
+        .catch(() => {});
+    },
+    (err) => showToast(extractErrorMessage(err)),
   );
+
+  if (root) {
+    render(
+      () => (
+        <OfflineOverlay>
+          <Show when={AppComponent()} fallback={<Spinner fullscreen />}>
+            {(App) => <Dynamic component={App()} />}
+          </Show>
+        </OfflineOverlay>
+      ),
+      root,
+    );
+  }
 }

--- a/frontend/src/rpc.ts
+++ b/frontend/src/rpc.ts
@@ -1,4 +1,5 @@
 import type { AppType } from "@backend/index";
 import { hc } from "hono/client";
+import { BACKEND_PREFIX } from "./backend-base";
 
-export const rpc = hc<AppType>(window.location.origin);
+export const rpc = hc<AppType>(`${window.location.origin}${BACKEND_PREFIX}`);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2071,3 +2071,101 @@ h1 {
   color: var(--color-muted);
   margin-top: 0.25rem;
 }
+
+/* ── Picker page ──────────────────────────────────────────────────
+ * Standalone view at "/" when the gateway has no backend selected.
+ * Intentionally minimal: this loads instead of the full app and
+ * should feel like a system menu, not a feature surface.
+ */
+
+.picker-root {
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.picker-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.picker-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.picker-status {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.picker-error {
+  color: var(--color-error);
+}
+
+.picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.picker-row {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  transition: border-color 0.1s, background 0.1s;
+}
+
+.picker-row-online:hover {
+  border-color: var(--color-accent);
+}
+
+.picker-row-offline {
+  opacity: 0.6;
+}
+
+.picker-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.picker-name {
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+
+.picker-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.picker-status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-muted);
+  display: inline-block;
+}
+
+.picker-status-dot.online {
+  background: var(--color-ok);
+}
+
+.picker-version {
+  font-family: var(--font-mono);
+}

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -5,29 +5,40 @@ deployment. Browsers reach it over HTTPS (terminated by Caddy upstream),
 backend hosts reach it via outbound WebSocket tunnels, and the gateway
 brokers HTTP requests between the two.
 
-In Phase 1 (this PR), the gateway is a thin proxy + tunnel server. The
-frontend is not yet embedded; the picker UI and WoL endpoints land in
-later phases.
+The gateway also serves the VoxPilot frontend (embedded via `embed.FS`):
+the picker page at `/`, and the chat app at `/backends/<name>/...`.
 
 ## Routing
 
-| Path                              | Handled by                         |
-| --------------------------------- | ---------------------------------- |
-| `GET  /api/gateway/tunnel`        | WebSocket; tunnel clients connect  |
-| `GET  /api/gateway/instances`     | JSON list of registered backends   |
-| `*    /backends/{name}/...`       | Proxied to that backend's tunnel   |
-| `*    /...`                       | 404 (Phase 2: frontend assets)     |
+| Path                                       | Handled by                              |
+| ------------------------------------------ | --------------------------------------- |
+| `GET  /api/gateway/tunnel`                 | WebSocket; tunnel clients connect       |
+| `GET  /api/gateway/instances`              | JSON list of registered backends        |
+| `*    /backends/{name}/(api\|oc\|mcp)/...` | Proxied to that backend's tunnel        |
+| `*    /backends/{name}/...` (other paths)  | SPA fallback to embedded `index.html`   |
+| `*    /assets/*`, `/icon-*.png`, etc.      | Embedded frontend assets                |
+| `*    /`                                   | Embedded frontend (renders the picker)  |
 
-Path stripping: a request for `/backends/devbox/api/health` arrives at the
-backend as `/api/health`. The original `Host` header is preserved.
+Path stripping for tunneled paths: a request for
+`/backends/devbox/api/health` arrives at the backend as `/api/health`.
+The original `Host` header is preserved.
+
+The frontend bundle uses `window.location.pathname` at module load to
+detect its prefix (see `frontend/src/backend-base.ts`):
+
+- `/` -> picker mode (lists registered backends)
+- `/backends/<name>/...` -> SPA boots, all `/api` and `/oc` calls go to
+  `/backends/<name>/api/...` and `/backends/<name>/oc/...`
+- Anything else -> standalone mode (Vite dev), API calls go to root
 
 ## Configuration
 
-| Env var                     | Default | Notes                                      |
-| --------------------------- | ------- | ------------------------------------------ |
-| `VPGW_BIND`                 | `:8080` | HTTP listen address                        |
-| `VPGW_TUNNEL_TOKEN`         | _none_  | **Required.** Shared secret for tunnels.   |
-| `VPGW_HEARTBEAT_TIMEOUT`    | `60s`   | Mark instance offline after this gap       |
+| Env var                     | Default | Notes                                           |
+| --------------------------- | ------- | ----------------------------------------------- |
+| `VPGW_BIND`                 | `:8080` | HTTP listen address                             |
+| `VPGW_TUNNEL_TOKEN`         | _none_  | **Required.** Shared secret for tunnels.        |
+| `VPGW_HEARTBEAT_TIMEOUT`    | `60s`   | Mark instance offline after this gap            |
+| `VPGW_FRONTEND_DIR`         | _empty_ | Override the embedded frontend (point at `frontend/dist`) |
 
 ## Tunnel protocol
 
@@ -46,39 +57,42 @@ SSE responses unbuffered.
 
 ## Build
 
+The gateway expects the frontend bundle at `gateway/static/`. Build the
+frontend first:
+
 ```sh
-go build -o voxpilot-gateway ./...
+( cd frontend && npm run build && cp -r dist/* ../gateway/static/ )
+go build -o voxpilot-gateway ./gateway/...
 ```
 
-A Dockerfile lives alongside this README (Phase 4 will wire it into the
-release pipeline).
+The release pipeline (Phase 4) will wire this together via Docker.
 
 ## Local smoke test
 
 ```sh
-# Terminal 1: gateway
+# Terminal 1: real VoxPilot backend
+( cd backend && VOXPILOT_PORT=18000 bun run src/index.ts )
+
+# Terminal 2: gateway with frontend embedded
 VPGW_BIND=:18080 VPGW_TUNNEL_TOKEN=dev ./voxpilot-gateway
 
-# Terminal 2: a fake local backend
-python3 -m http.server 18000
-
-# Terminal 3: tunnel client (from ../tunnel-client)
+# Terminal 3: tunnel client
 VOXPILOT_GATEWAY_URL=ws://127.0.0.1:18080/api/gateway/tunnel \
   VOXPILOT_GATEWAY_TOKEN=dev \
-  VOXPILOT_INSTANCE_NAME=smoke \
+  VOXPILOT_INSTANCE_NAME=devbox \
   VOXPILOT_LOCAL_URL=http://127.0.0.1:18000 \
   ./voxpilot-tunnel
 
-# Terminal 4: hit the gateway
-curl http://127.0.0.1:18080/api/gateway/instances
-curl http://127.0.0.1:18080/backends/smoke/
+# Browser:
+#   http://localhost:18080/                  -> picker
+#   http://localhost:18080/backends/devbox/  -> chat app
 ```
 
-## Known limitations (Phase 1)
+## Known limitations
 
 - No persistent state. Gateway restart loses all registrations until clients
   reconnect (a few seconds with default backoff).
 - No WebSocket proxying through the tunnel. SSE works; raw WS upgrades do
   not. VoxPilot does not currently use WS upstream of the tunnel.
-- No frontend serving. Picker UI lands in Phase 2.
 - No WoL endpoint. Lands in Phase 3.
+- Frontend/backend version skew not yet detected/warned. Lands in Phase 3.

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -60,13 +60,24 @@ func main() {
 	mux.HandleFunc("GET /api/gateway/instances", func(w http.ResponseWriter, r *http.Request) {
 		writeInstances(w, registry)
 	})
-	mux.Handle("/backends/", &proxyHandler{registry: registry})
 
-	// Phase 1 fallback: anything else is a 404. Phase 2 will replace this
-	// with embedded frontend assets + SPA fallback.
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	})
+	// Frontend: embedded SolidJS bundle, with SPA fallback to index.html
+	// for any path that doesn't match an asset. The bundle handles both
+	// the picker (rendered when path = "/") and the chat app (rendered
+	// for /backends/<name>/...).
+	staticH, err := newStaticHandler()
+	if err != nil {
+		log.Fatalf("frontend: %v", err)
+	}
+
+	// /backends/{name}/(api|oc|mcp)/... -> proxy to the backend.
+	// /backends/{name}/<anything else>  -> serve the SPA (with prefix
+	// stripped so asset URLs resolve correctly).
+	mux.Handle("/backends/", &proxyHandler{registry: registry, next: staticH})
+
+	// Root: picker page (and any client-side route under "/" that the
+	// SPA might add later).
+	mux.Handle("/", staticH)
 
 	srv := &http.Server{
 		Addr:    bind,

--- a/gateway/proxy.go
+++ b/gateway/proxy.go
@@ -14,19 +14,31 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
-// proxyHandler routes /backends/{name}/... to the named instance's tunnel.
-// Path-prefix stripping: the backend sees the request at the same path it
-// would if it were called directly (e.g. /backends/devbox/api/health
-// becomes /api/health).
+// proxyHandler routes /backends/{name}/{api|oc|mcp}/... to the named
+// instance's tunnel. Anything else under /backends/{name}/ is the
+// frontend (handled by the static handler with SPA fallback).
+//
+// Path-prefix stripping: /backends/devbox/api/health becomes /api/health
+// at the backend. The original Host header is preserved.
 type proxyHandler struct {
 	registry *registry
+	// next is the handler to fall back to when the path is under
+	// /backends/<name>/ but not one of the proxied subpaths -- i.e.,
+	// requests for the SPA itself. Typically the static file server.
+	next http.Handler
 }
 
+// proxiedSubpaths are the path segments (immediately after the backend
+// name) that get tunneled to the backend. Everything else under
+// /backends/<name>/ is served by the SPA (index.html with SPA fallback).
+var proxiedSubpaths = []string{"api", "oc", "mcp"}
+
 func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// /backends/{name}/...  -> name = first segment after the prefix
+	// /backends/{name}/{...}  -- name is the first segment, then "/".
 	rest := strings.TrimPrefix(r.URL.Path, "/backends/")
 	if rest == r.URL.Path {
-		http.NotFound(w, r)
+		// Shouldn't happen given the mux pattern, but be defensive.
+		h.next.ServeHTTP(w, r)
 		return
 	}
 	slash := strings.IndexByte(rest, '/')
@@ -40,6 +52,34 @@ func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if name == "" {
 		http.NotFound(w, r)
+		return
+	}
+
+	// Decide whether to tunnel or to serve the SPA. The first segment of
+	// `tail` after the leading slash determines this.
+	tailFirst := ""
+	if len(tail) > 1 {
+		if i := strings.IndexByte(tail[1:], '/'); i >= 0 {
+			tailFirst = tail[1 : 1+i]
+		} else {
+			tailFirst = tail[1:]
+		}
+	}
+	isProxied := false
+	for _, p := range proxiedSubpaths {
+		if tailFirst == p {
+			isProxied = true
+			break
+		}
+	}
+	if !isProxied {
+		// SPA fallback. Strip just /backends/<name> so the static handler
+		// resolves assets and falls back to index.html. Asset requests
+		// (e.g. /backends/devbox/assets/main.js) thus resolve to the
+		// static FS at /assets/main.js.
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = tail
+		h.next.ServeHTTP(w, r2)
 		return
 	}
 

--- a/gateway/static.go
+++ b/gateway/static.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"embed"
+	"errors"
+	"io/fs"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Embedded frontend bundle. Built by `npm run build` in frontend/, then
+// copied into static/ here by the gateway's build pipeline (see
+// scripts/build-release.sh / Dockerfile).
+//
+// embed:all is required to include hashed asset filenames (otherwise
+// files starting with "_" or "." would be excluded).
+//
+//go:embed all:static
+var embeddedFS embed.FS
+
+// staticHandler serves the embedded frontend with SPA fallback to
+// index.html for any path that doesn't match an asset.
+//
+// In dev (or for hot-iteration of just the frontend), set VPGW_FRONTEND_DIR
+// to a directory on disk; the gateway will serve from there instead of the
+// embedded copy.
+func newStaticHandler() (http.Handler, error) {
+	if dir := os.Getenv("VPGW_FRONTEND_DIR"); dir != "" {
+		return spaFileServer(http.Dir(dir)), nil
+	}
+	sub, err := fs.Sub(embeddedFS, "static")
+	if err != nil {
+		return nil, err
+	}
+	// Detect "no frontend bundled" so we can give a clear error rather than
+	// 404-ing at runtime (this happens when the gateway is built without
+	// the build step that copies frontend/dist into gateway/static/).
+	if _, err := fs.Stat(sub, "index.html"); err != nil {
+		return nil, errors.New("no embedded frontend (gateway/static/index.html missing); rebuild after `npm run build` in frontend/")
+	}
+	return spaFileServer(http.FS(sub)), nil
+}
+
+// spaFileServer serves files from the given FS, falling back to /index.html
+// for any path that doesn't resolve to a file (so the SolidJS router can
+// pick it up client-side).
+func spaFileServer(root http.FileSystem) http.Handler {
+	fileSrv := http.FileServer(root)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try to open the requested path. If it doesn't exist, serve
+		// index.html instead -- the SPA router will handle it.
+		// Skip the fallback for asset-style paths (anything with an
+		// extension): those should 404 cleanly so the browser doesn't
+		// try to interpret HTML as JS or CSS.
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path == "" {
+			fileSrv.ServeHTTP(w, r)
+			return
+		}
+		f, err := root.Open(path)
+		if err == nil {
+			f.Close()
+			fileSrv.ServeHTTP(w, r)
+			return
+		}
+		if hasExt(path) {
+			http.NotFound(w, r)
+			return
+		}
+		// SPA fallback: rewrite to index.html.
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileSrv.ServeHTTP(w, r2)
+	})
+}
+
+func hasExt(path string) bool {
+	// Last segment after the last '/'.
+	if i := strings.LastIndexByte(path, '/'); i >= 0 {
+		path = path[i+1:]
+	}
+	return strings.LastIndexByte(path, '.') >= 0
+}

--- a/gateway/static/.gitignore
+++ b/gateway/static/.gitignore
@@ -1,0 +1,5 @@
+# Built frontend assets are produced by `npm run build` in frontend/
+# and copied in by the build pipeline; never commit them.
+*
+!.keep
+!.gitignore


### PR DESCRIPTION
## Summary

Phase 2 of the multi-host gateway architecture. Stacked on top of PR #61.

The gateway now embeds the SolidJS bundle and serves it at:
- `/` -> **picker page** listing registered backends
- `/backends/<name>/...` -> the chat app, scoped to that backend

Routing under `/backends/<name>/` is split: requests to `api/`, `oc/`, `mcp/` are tunneled to the backend; everything else (assets, SPA routes) falls back to `index.html`. The SPA reads `window.location.pathname` at module load to discover its prefix and configures its OpenCode SDK + Hono RPC clients accordingly.

## Architectural choice: page reload between backends

Switching backends is a full page navigation, not SPA navigation. The app's module-level singletons (`api-client.ts`'s SSE pump, `store.ts`'s top-level `await(init)`, `navigation.ts`'s hash sync) are all bound to one backend at boot. Threading a backend parameter through every call site would have been a much larger refactor; the page reload sidesteps it cleanly.

## What you get

- Picker at `/` — list of registered backends with online/offline dots and version. Polls `/api/gateway/instances` every 5s.
- Chat app at `/backends/<name>/` — completely unchanged from today's UX, just with prefixed API URLs.
- localStorage keys auto-namespaced per backend via `backendStorageKey()` (only `voxpilot:wakeUrl` today; review-state was already session-scoped which is globally unique).

## What's preserved

- **Vite dev workflow** — `import.meta.env.DEV` short-circuits picker mode, so `just dev` works exactly as before against a local backend.
- All existing app code (components, store, streaming, navigation) untouched.
- PWA / service worker still works (per-URL cache keys naturally separate per backend).

## Smoke testing

Verified in a real browser via the wl-chrome CDP instance:

- `http://gateway/` -> picker, shows the registered backend
- `http://gateway/backends/<name>/` -> SPA boots, projects load, SSE events stream, model picker renders. **Zero console errors, zero failed requests.**
- Vite dev at `http://localhost:3000` -> standalone app against local backend, unchanged

## Out of scope (future PRs)

- Build pipeline doesn't auto-copy `frontend/dist/` into `gateway/static/` (PR 4 wires this via Docker)
- WoL endpoints + version skew warnings (PR 3)
- `tsnet-proxy/` deletion + packaging rewrite (PR 4)