### PR TITLE
PR 3/4: Wake-on-LAN, version skew detection, registry persistence

### DIFF
--- a/frontend/src/Picker.tsx
+++ b/frontend/src/Picker.tsx
@@ -8,6 +8,7 @@
  */
 
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { FRONTEND_VERSION } from "./backend-base";
 
 type InstanceView = {
   name: string;
@@ -75,18 +76,26 @@ export function Picker() {
             fallback={<p class="picker-status">Loading...</p>}
           >
             <p class="picker-status picker-error">
-              Could not load backends: {(state() as { message: string }).message}
+              Could not load backends:{" "}
+              {(state() as { message: string }).message}
             </p>
           </Show>
         }
       >
-        <PickerList state={state} />
+        <PickerList state={state} onChange={refresh} />
       </Show>
+      <footer class="picker-footer">
+        gateway frontend{" "}
+        <span class="picker-version">{FRONTEND_VERSION}</span>
+      </footer>
     </div>
   );
 }
 
-function PickerList(props: { state: () => FetchState }) {
+function PickerList(props: {
+  state: () => FetchState;
+  onChange: () => Promise<void>;
+}) {
   const instances = () => {
     const s = props.state();
     return s.kind === "ok" ? s.instances : [];
@@ -97,14 +106,21 @@ function PickerList(props: { state: () => FetchState }) {
       fallback={<p class="picker-status">No backends registered yet.</p>}
     >
       <ul class="picker-list">
-        <For each={instances()}>{(inst) => <PickerRow inst={inst} />}</For>
+        <For each={instances()}>
+          {(inst) => <PickerRow inst={inst} onWake={props.onChange} />}
+        </For>
       </ul>
     </Show>
   );
 }
 
-function PickerRow(props: { inst: InstanceView }) {
+function PickerRow(props: {
+  inst: InstanceView;
+  onWake: () => Promise<void>;
+}) {
   const href = () => `/backends/${encodeURIComponent(props.inst.name)}/`;
+  const skew = () =>
+    Boolean(props.inst.version) && props.inst.version !== FRONTEND_VERSION;
   return (
     <li
       classList={{
@@ -116,6 +132,14 @@ function PickerRow(props: { inst: InstanceView }) {
       <a class="picker-link" href={href()}>
         <span class="picker-name">{props.inst.name}</span>
         <span class="picker-meta">
+          <Show when={skew()}>
+            <span
+              class="picker-skew"
+              title={`Backend version ${props.inst.version} differs from gateway frontend ${FRONTEND_VERSION}; the UI may not load correctly.`}
+            >
+              skew
+            </span>
+          </Show>
           <span
             classList={{
               "picker-status-dot": true,
@@ -126,6 +150,55 @@ function PickerRow(props: { inst: InstanceView }) {
           <span class="picker-version">{props.inst.version || "unknown"}</span>
         </span>
       </a>
+      <Show when={!props.inst.online && props.inst.has_wake}>
+        <WakeButton name={props.inst.name} onWake={props.onWake} />
+      </Show>
     </li>
+  );
+}
+
+function WakeButton(props: { name: string; onWake: () => Promise<void> }) {
+  const [busy, setBusy] = createSignal(false);
+  const [status, setStatus] = createSignal<string>("");
+
+  async function handleClick(e: MouseEvent) {
+    e.preventDefault();
+    if (busy()) return;
+    setBusy(true);
+    setStatus("waking...");
+    try {
+      const resp = await fetch(
+        `/api/gateway/wake/${encodeURIComponent(props.name)}`,
+        { method: "POST" },
+      );
+      const body = (await resp.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (resp.ok && body.ok !== false) {
+        setStatus("sent");
+      } else {
+        setStatus(body.error || `wake failed (HTTP ${resp.status})`);
+      }
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+      // Refresh the instance list -- if the host comes back up quickly,
+      // it'll show as online on the next poll.
+      void props.onWake();
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      class="picker-wake-btn"
+      disabled={busy()}
+      onClick={handleClick}
+      title={status() || "Send Wake-on-LAN webhook"}
+    >
+      {busy() ? "waking..." : status() || "wake"}
+    </button>
   );
 }

--- a/frontend/src/backend-base.ts
+++ b/frontend/src/backend-base.ts
@@ -69,6 +69,16 @@ export const BACKEND_NAME = name;
 export const PICKER_MODE = pickerMode;
 
 /**
+ * Bundle version, injected at build time by Vite's `define`. The picker
+ * surfaces this and warns when a backend reports a different version.
+ */
+declare const __VOXPILOT_FRONTEND_VERSION__: string;
+export const FRONTEND_VERSION =
+  typeof __VOXPILOT_FRONTEND_VERSION__ !== "undefined"
+    ? __VOXPILOT_FRONTEND_VERSION__
+    : "0.0.0-dev";
+
+/**
  * Build a localStorage key that's automatically scoped to the current
  * backend, so the same browser can hold separate state per backend
  * without collisions. In standalone mode (no backend name) the key is

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2169,3 +2169,57 @@ h1 {
 .picker-version {
   font-family: var(--font-mono);
 }
+
+.picker-row {
+  /* Override: wake button needs to live next to the link */
+  display: flex;
+  flex-direction: column;
+}
+
+.picker-row-offline .picker-link {
+  /* Offline rows aren't clickable in a useful way until woken; keep the
+   * link but don't underline it on hover. */
+  cursor: default;
+}
+
+.picker-wake-btn {
+  align-self: stretch;
+  background: var(--color-option-bg);
+  color: var(--color-text);
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.picker-wake-btn:hover:not(:disabled) {
+  background: var(--color-accent);
+  color: var(--color-white);
+}
+
+.picker-wake-btn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.picker-skew {
+  font-size: 0.7rem;
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.picker-footer {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  text-align: center;
+  font-family: var(--font-mono);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import { VitePWA } from "vite-plugin-pwa";
 
 const apiTarget = process.env.VOXPILOT_API_TARGET ?? "http://127.0.0.1:8000";
 
+// Version baked into the bundle so the picker can warn about
+// frontend/backend skew. Set by the release pipeline; falls back to a
+// dev marker when running locally.
+const buildVersion = process.env.VOXPILOT_VERSION ?? "0.0.0-dev";
+
 export default defineConfig({
   plugins: [
     solidPlugin(),
@@ -78,5 +83,8 @@ export default defineConfig({
   build: {
     target: "es2022",
     outDir: "dist",
+  },
+  define: {
+    __VOXPILOT_FRONTEND_VERSION__: JSON.stringify(buildVersion),
   },
 });

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -14,6 +14,8 @@ the picker page at `/`, and the chat app at `/backends/<name>/...`.
 | ------------------------------------------ | --------------------------------------- |
 | `GET  /api/gateway/tunnel`                 | WebSocket; tunnel clients connect       |
 | `GET  /api/gateway/instances`              | JSON list of registered backends        |
+| `GET  /api/gateway/info`                   | `{gateway_version}`                     |
+| `POST /api/gateway/wake/{name}`            | Forwards to that backend's `wake_url`   |
 | `*    /backends/{name}/(api\|oc\|mcp)/...` | Proxied to that backend's tunnel        |
 | `*    /backends/{name}/...` (other paths)  | SPA fallback to embedded `index.html`   |
 | `*    /assets/*`, `/icon-*.png`, etc.      | Embedded frontend assets                |
@@ -38,7 +40,30 @@ detect its prefix (see `frontend/src/backend-base.ts`):
 | `VPGW_BIND`                 | `:8080` | HTTP listen address                             |
 | `VPGW_TUNNEL_TOKEN`         | _none_  | **Required.** Shared secret for tunnels.        |
 | `VPGW_HEARTBEAT_TIMEOUT`    | `60s`   | Mark instance offline after this gap            |
+| `VPGW_DATA_DIR`             | _empty_ | If set, persist registry to `<dir>/instances.json` so wake-on-LAN works after gateway restart |
 | `VPGW_FRONTEND_DIR`         | _empty_ | Override the embedded frontend (point at `frontend/dist`) |
+
+Gateway version is injected at build time:
+
+```sh
+go build -ldflags="-X main.version=$(git describe --tags --always)" -o voxpilot-gateway ./...
+```
+
+Frontend version is injected at build time via the `VOXPILOT_VERSION`
+environment variable read by Vite. The picker compares the two and shows
+a "skew" warning per backend if they differ.
+
+## Wake-on-LAN
+
+Each tunnel client may report a `wake_url` (a Home Assistant webhook
+URL or any HTTP endpoint that triggers a WoL packet). The gateway
+persists this in `instances.json` so it survives both the backend going
+offline and the gateway restarting.
+
+`POST /api/gateway/wake/{name}` causes the gateway to POST to that URL
+(no body, 10s timeout) and returns the upstream status as JSON. The
+picker UI exposes this as a "wake" button next to offline backends that
+have a `wake_url` configured.
 
 ## Tunnel protocol
 
@@ -90,9 +115,5 @@ VOXPILOT_GATEWAY_URL=ws://127.0.0.1:18080/api/gateway/tunnel \
 
 ## Known limitations
 
-- No persistent state. Gateway restart loses all registrations until clients
-  reconnect (a few seconds with default backoff).
 - No WebSocket proxying through the tunnel. SSE works; raw WS upgrades do
   not. VoxPilot does not currently use WS upstream of the tunnel.
-- No WoL endpoint. Lands in Phase 3.
-- Frontend/backend version skew not yet detected/warned. Lands in Phase 3.

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -26,6 +27,12 @@ import (
 	"syscall"
 	"time"
 )
+
+// version is the gateway+frontend bundle version, injected at build
+// time via -ldflags="-X main.version=...". The frontend bundle has its
+// own version baked in via Vite's `define`; both should match for any
+// given gateway image.
+var version = "0.0.0-dev"
 
 func envOr(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok {
@@ -40,6 +47,7 @@ func main() {
 	if tunnelToken == "" {
 		log.Fatal("VPGW_TUNNEL_TOKEN must be set (shared secret presented by tunnel clients)")
 	}
+	dataDir := envOr("VPGW_DATA_DIR", "")
 
 	heartbeatTimeout := 60 * time.Second
 	if v := os.Getenv("VPGW_HEARTBEAT_TIMEOUT"); v != "" {
@@ -50,7 +58,7 @@ func main() {
 		heartbeatTimeout = d
 	}
 
-	registry := newRegistry(heartbeatTimeout)
+	registry := newRegistry(heartbeatTimeout, dataDir)
 
 	mux := http.NewServeMux()
 	mux.Handle("GET /api/gateway/tunnel", &tunnelHandler{
@@ -60,6 +68,14 @@ func main() {
 	mux.HandleFunc("GET /api/gateway/instances", func(w http.ResponseWriter, r *http.Request) {
 		writeInstances(w, registry)
 	})
+	mux.HandleFunc("GET /api/gateway/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"gateway_version": version,
+		})
+	})
+	mux.Handle("POST /api/gateway/wake/{name}", &wakeHandler{registry: registry})
 
 	// Frontend: embedded SolidJS bundle, with SPA fallback to index.html
 	// for any path that doesn't match an asset. The bundle handles both
@@ -102,7 +118,7 @@ func main() {
 		registry.closeAll()
 	}()
 
-	log.Printf("voxpilot-gateway listening on %s", bind)
+	log.Printf("voxpilot-gateway %s listening on %s", version, bind)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("listen: %v", err)
 	}

--- a/gateway/registry.go
+++ b/gateway/registry.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
+	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -11,35 +16,53 @@ import (
 
 // instance is a single registered backend, with its yamux session if connected.
 //
-// Lifecycle: created on tunnel connect (registerControl), updated by heartbeats,
-// removed on tunnel disconnect. Phase 1 keeps no on-disk state; if the gateway
-// restarts, registrations are lost (clients reconnect within seconds).
+// Lifecycle:
+//   - Created or revived on tunnel connect (tunnel.go)
+//   - Updated by heartbeats
+//   - session/transport go nil on disconnect, but the entry stays so we
+//     can wake it with the persisted wake_url
 type instance struct {
 	name        string
-	wakeURL     string // optional HA webhook; nil for now in phase 1
+	wakeURL     string // optional HA webhook
 	version     string
-	session     *yamux.Session
-	transport   *yamuxTransport // built once per session
+	session     *yamux.Session  // nil when disconnected
+	transport   *yamuxTransport // nil when disconnected
 	connectedAt time.Time
 	lastSeen    time.Time
+}
+
+// instanceRecord is the on-disk shape -- only the fields that survive
+// gateway restarts. The live session/transport can't be persisted; they're
+// rebuilt when the tunnel client reconnects.
+type instanceRecord struct {
+	Name    string `json:"name"`
+	WakeURL string `json:"wake_url,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type registry struct {
 	mu               sync.RWMutex
 	instances        map[string]*instance
 	heartbeatTimeout time.Duration
+	dataDir          string // empty = no persistence
 }
 
-func newRegistry(heartbeatTimeout time.Duration) *registry {
-	return &registry{
+func newRegistry(heartbeatTimeout time.Duration, dataDir string) *registry {
+	r := &registry{
 		instances:        map[string]*instance{},
 		heartbeatTimeout: heartbeatTimeout,
+		dataDir:          dataDir,
 	}
+	if dataDir != "" {
+		if err := r.load(); err != nil {
+			log.Printf("registry: load failed: %v", err)
+		}
+	}
+	return r
 }
 
-// register installs (or replaces) an instance. If a previous session exists
-// for the same name, it is closed -- last-write-wins, with a warning logged
-// by the caller.
+// register installs (or revives) an instance. If a previous live session
+// existed for the same name, it is closed -- last-write-wins.
 func (r *registry) register(inst *instance) (replaced bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -49,20 +72,24 @@ func (r *registry) register(inst *instance) (replaced bool) {
 		replaced = true
 	}
 	r.instances[inst.name] = inst
+	r.persistLocked()
 	return
 }
 
-// remove drops an instance, but only if the recorded session matches the one
-// passed in. This avoids races where a reconnect installs a new session
-// between the time the old session's read loop exits and we get here.
-func (r *registry) remove(name string, sess *yamux.Session) {
+// markDisconnected drops the live session/transport for an instance but
+// keeps its persisted record (name, wake_url, version) so it's still
+// listable / wakable by name.
+func (r *registry) markDisconnected(name string, sess *yamux.Session) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	inst, ok := r.instances[name]
 	if !ok || inst.session != sess {
+		// Either the instance was already replaced by a newer connection,
+		// or it never existed; nothing to do.
 		return
 	}
-	delete(r.instances, name)
+	inst.session = nil
+	inst.transport = nil
 }
 
 func (r *registry) get(name string) *instance {
@@ -90,6 +117,69 @@ func (r *registry) closeAll() {
 			_ = inst.session.Close()
 		}
 	}
+}
+
+// persistLocked writes the current instance set to disk. Caller must
+// hold r.mu (write lock). Errors are logged, not returned -- registry
+// state is more important than disk durability here.
+func (r *registry) persistLocked() {
+	if r.dataDir == "" {
+		return
+	}
+	records := make([]instanceRecord, 0, len(r.instances))
+	for _, inst := range r.instances {
+		records = append(records, instanceRecord{
+			Name:    inst.name,
+			WakeURL: inst.wakeURL,
+			Version: inst.version,
+		})
+	}
+	if err := os.MkdirAll(r.dataDir, 0o755); err != nil {
+		log.Printf("registry: mkdir %s: %v", r.dataDir, err)
+		return
+	}
+	path := filepath.Join(r.dataDir, "instances.json")
+	tmp := path + ".tmp"
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		log.Printf("registry: marshal: %v", err)
+		return
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		log.Printf("registry: write %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		log.Printf("registry: rename %s -> %s: %v", tmp, path, err)
+	}
+}
+
+func (r *registry) load() error {
+	path := filepath.Join(r.dataDir, "instances.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	var records []instanceRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, rec := range records {
+		// Restored instances start in disconnected state; tunnel clients
+		// will revive them on next register.
+		r.instances[rec.Name] = &instance{
+			name:    rec.Name,
+			wakeURL: rec.WakeURL,
+			version: rec.Version,
+		}
+	}
+	log.Printf("registry: loaded %d persisted instance(s) from %s", len(records), path)
+	return nil
 }
 
 // instanceView is the JSON shape returned by /api/gateway/instances.

--- a/gateway/tunnel.go
+++ b/gateway/tunnel.go
@@ -116,8 +116,8 @@ func (h *tunnelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("tunnel: %s connected (version=%s)", inst.name, inst.version)
 	}
 	defer func() {
-		h.registry.remove(inst.name, sess)
-		log.Printf("tunnel: %s disconnected", inst.name)
+		h.registry.markDisconnected(inst.name, sess)
+		log.Printf("tunnel: %s disconnected (instance retained for wake-on-lan)", inst.name)
 	}()
 
 	// Read heartbeats from the control stream until the client goes away.

--- a/gateway/wake.go
+++ b/gateway/wake.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// wakeHandler proxies to the per-host wake URL (typically a Home
+// Assistant webhook). The instance must be registered (live or stale);
+// if not, returns 404. If the instance has no wake_url configured,
+// returns 422.
+//
+// The wake URL is invoked with a POST and an empty body. Whatever Home
+// Assistant returns is forwarded back to the caller, plus a small JSON
+// summary the picker UI can show.
+type wakeHandler struct {
+	registry *registry
+}
+
+type wakeResponse struct {
+	OK              bool   `json:"ok"`
+	UpstreamStatus  int    `json:"upstream_status,omitempty"`
+	UpstreamMessage string `json:"upstream_message,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+var wakeClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+func (h *wakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	inst := h.registry.get(name)
+	if inst == nil {
+		writeWakeJSON(w, http.StatusNotFound, wakeResponse{
+			Error: "no such backend",
+		})
+		return
+	}
+	if inst.wakeURL == "" {
+		writeWakeJSON(w, http.StatusUnprocessableEntity, wakeResponse{
+			Error: "backend has no wake_url configured",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, inst.wakeURL, nil)
+	if err != nil {
+		writeWakeJSON(w, http.StatusInternalServerError, wakeResponse{
+			Error: err.Error(),
+		})
+		return
+	}
+	resp, err := wakeClient.Do(req)
+	if err != nil {
+		// Timeout, connection refused, etc. Surface the cause but report
+		// 502 -- the gateway itself worked, the upstream did not.
+		if errors.Is(err, context.DeadlineExceeded) {
+			err = errors.New("upstream timeout")
+		}
+		log.Printf("wake: %s -> %s failed: %v", name, inst.wakeURL, err)
+		writeWakeJSON(w, http.StatusBadGateway, wakeResponse{
+			Error: err.Error(),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read up to 4 KB of upstream body so we can echo something useful
+	// back without buffering arbitrary payloads.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+
+	ok := resp.StatusCode >= 200 && resp.StatusCode < 300
+	status := http.StatusOK
+	if !ok {
+		status = http.StatusBadGateway
+	}
+	log.Printf("wake: %s -> %s status=%d", name, inst.wakeURL, resp.StatusCode)
+	writeWakeJSON(w, status, wakeResponse{
+		OK:              ok,
+		UpstreamStatus:  resp.StatusCode,
+		UpstreamMessage: msg,
+	})
+}
+
+func writeWakeJSON(w http.ResponseWriter, status int, body wakeResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/tunnel-client/README.md
+++ b/tunnel-client/README.md
@@ -29,7 +29,7 @@ a `yamux` client session, and:
 | `VOXPILOT_GATEWAY_TOKEN`    | _none_               | **Required.** Shared with gateway. |
 | `VOXPILOT_LOCAL_URL`        | `http://127.0.0.1:8000` | Where the backend listens       |
 | `VOXPILOT_INSTANCE_NAME`    | `os.Hostname()`      | Becomes `/backends/<name>/...`     |
-| `VOXPILOT_WAKE_URL`         | _empty_              | Optional HA webhook (Phase 3)      |
+| `VOXPILOT_WAKE_URL`         | _empty_              | Optional URL the gateway POSTs to wake this host (e.g. an HA webhook that broadcasts a WoL packet). Reported at registration; persisted by the gateway so wake works even when this client is offline. |
 | `VOXPILOT_VERSION`          | `0.0.0-dev`          | Build-time injected normally       |
 
 ## Reconnection


### PR DESCRIPTION
## Summary

Phase 3 of the multi-host gateway architecture. Stacked on top of PR #62.

## Wake-on-LAN

`POST /api/gateway/wake/{name}` causes the gateway to POST to that backend's `wake_url` (typically a Home Assistant webhook that broadcasts a WoL packet) with no body and a 10s timeout. Response:

```json
{"ok": true, "upstream_status": 200, "upstream_message": "{...}"}
```

Or `{ok: false, error: "..."}` for failures. Picker UI shows a "wake" button next to offline backends that have a `wake_url` configured, with status messages (`waking...`, `sent`, error).

## Registry persistence

`VPGW_DATA_DIR` (optional) makes the registry write `instances.json` to disk (atomic via tmp+rename). Backends survive both:
- Going offline (tunnel disconnects, but the record stays so wake works)
- Gateway restarting (records are reloaded; backends reconnect within seconds)

Without `VPGW_DATA_DIR`, the registry stays in-memory only.

## Version skew detection

- `/api/gateway/info` exposes the gateway version (injected via `-ldflags="-X main.version=..."`)
- Frontend bundle has its own version baked in via Vite's `define` from `VOXPILOT_VERSION`
- Picker shows a `SKEW` badge next to backends whose reported version differs from the frontend's, with a tooltip explaining the implication
- Footer shows the gateway frontend version

## Smoke testing

- **Wake online**: works, returns 200 + upstream body.
- **Wake offline**: tunnel killed, instance shows `online:false`, wake still hits the persisted URL.
- **Persistence**: gateway restarted with same `VPGW_DATA_DIR`, instance record reloaded from `instances.json` including `wake_url`; wake still works.
- **Skew badge**: shown when versions differ, hidden when they match.
- All verified end-to-end via wl-chrome CDP.

## Out of scope (PR 4)

- `tsnet-proxy/` deletion + packaging README rewrite
- Build-script + release-workflow changes (Docker image build/push, version threading end-to-end, dropping the now-useless `static/` dir from the backend tarball)