### PR TITLE
Drop hardcoded PATH from systemd unit

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,6 +16,20 @@ service. Extract to `~/.local/share/`, symlink the unit file, enable.
 - An OpenAI-compatible LLM endpoint reachable from this machine (configured
   via `opencode`'s own config -- see https://opencode.ai/docs/providers)
 
+> **PATH note:** systemd `--user` services don't source `~/.bashrc` /
+> `~/.zshrc`, so they only see the user manager's `PATH` (typically
+> `/usr/local/bin:/usr/bin:/bin` plus whatever `pam_env`/`environment.d`
+> adds). If `opencode` (or any other CLI VoxPilot calls) lives in
+> `~/.bun/bin`, `~/.npm-global/bin`, an asdf/mise shim dir, etc., add that
+> directory to `~/.config/environment.d/10-voxpilot.conf`:
+>
+> ```ini
+> PATH=$HOME/.bun/bin:$HOME/.local/bin:${PATH}
+> ```
+>
+> Then `systemctl --user daemon-reexec` (or log out and back in) so the
+> user manager re-reads it. See `environment.d(5)`.
+
 ### One-time setup
 
 ```sh

--- a/packaging/systemd/voxpilot.service
+++ b/packaging/systemd/voxpilot.service
@@ -13,8 +13,16 @@ Restart=on-failure
 RestartSec=5
 StartLimitBurst=3
 StartLimitIntervalSec=60
-# opencode may live in any of these install locations; cover them all.
-Environment=PATH=%h/.bun/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+# PATH is intentionally not set here. systemd --user inherits PATH from the
+# user manager, which users can extend declaratively via
+# ~/.config/environment.d/*.conf (see environment.d(5)) -- the right layer
+# for "where do my CLIs live". Hardcoding PATH here would override anything
+# the user configured there, breaking opencode/td/kagi/etc. that live in
+# non-default locations (~/.bun/bin, ~/.npm-global/bin, asdf shims, ...).
+#
+# If the user manager's PATH doesn't include the location of `opencode`,
+# voxpilot will fail to spawn it; the fix is to add that directory to
+# ~/.config/environment.d/, not to this unit.
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

- Remove `Environment=PATH=%h/.bun/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin` from `packaging/systemd/voxpilot.service`.
- Document the new contract in `packaging/README.md`: users extend the user manager's PATH via `~/.config/environment.d/*.conf`.

## Why

systemd `--user` services inherit `PATH` from the user manager. The unit was overriding that with a hardcoded list, which:

- Silently clobbered any PATH extension the user had configured (asdf, mise, `~/.npm-global/bin`, nix profile, custom locations).
- Required a unit-file edit -- which gets clobbered on next install since the unit ships in the tarball -- to add a new directory.
- Hid the intent. Curating PATH isn't voxpilot's job; it's the user manager's job, and there's a documented declarative mechanism (`environment.d(5)`) for it.

After this change, voxpilot inherits whatever the user manager has, which users can extend in one place that affects all their user services.

## Migration

Users who relied on the hardcoded PATH (i.e. opencode in `~/.bun/bin` and nothing in their environment.d) need to add a one-line file:

```ini
# ~/.config/environment.d/10-voxpilot.conf
PATH=$HOME/.bun/bin:$HOME/.local/bin:${PATH}
```

Then `systemctl --user daemon-reexec`. This is now in the README.

## Test

Local install + restart; `tr '\0' '\n' < /proc/$(systemctl --user show voxpilot -p MainPID --value)/environ | grep PATH` shows the user manager's PATH (with `~/.npm-global/bin` from my own `environment.d`), no longer the hardcoded one.